### PR TITLE
docs: lift "OS and hypervisor support" from h1 to h2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dpkg-buildpackage -b -us -uc
 If you have your Ada toolchain installed in an unusual location,
 it's better to ensure you have it in your `$PATH`.
 
-# OS and hypervisor support
+## OS and hypervisor support
 
 CPUID-based checks that can detect KVM, Xen HVM, VMware, bhyve, and Hyper-V are
 supported on any OS.


### PR DESCRIPTION
## Summary

Fix heading hierarchy in `README.md`: `# OS and hypervisor support` → `## OS and hypervisor support`. The h1 made it a sibling of the doc title rather than the other `## Building` section.

## Why this PR exists

Filed primarily as an **operational test PR** while validating the **T8850 Cat 1 pre-flight ruleset migration** on `vyos/hvinfo@current` (Phase 1 P2, ruleset id 16845685). The migrated ruleset requires 2 approvals; OrganizationAdmin bypass should permit admin merge. This PR exercises that path.

Migration plan: `~/.claude/plans/2026-05-25-classic-to-rulesets-migration.md` (v6, 5 Plan Reviewer rounds).

The fix itself is a real (if trivial) documentation improvement.

## Backport

None. Docs-only change on `current`. Optional backport to release branches if desired.

🤖 Generated by [robots](https://vyos.io)