### PR TITLE
T8943: migrate branch refs current->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [current]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:

--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - current
+      - rolling
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs current->rolling; action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943