### PR TITLE
T8943: revert(mirror-rollout-2): roll hvinfo back to post-1b wrapper

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling, production]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,13 +14,16 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
PR #19 (canonical stub) failed mirror auto-merge ([run 26696683755](https://github.com/vyos/hvinfo/actions/runs/26696683755)). Same source/target 1c divergence as vyos-github-actions ([VyOS-Networks/hvinfo#11](https://github.com/VyOS-Networks/hvinfo/pull/11) CLOSED with CONFLICTING). Reverting source-side per canonical-stub permissions fix plan Task 8 failure-handling. hvinfo excluded from rollout pending divergence reconciliation.

Advances: T8943

🤖 Generated by [robots](https://vyos.io)